### PR TITLE
Update models-map-to-dot.js to accept content models to have special characters in like [] and ->

### DIFF
--- a/src/models-map-to-dot.js
+++ b/src/models-map-to-dot.js
@@ -8,7 +8,7 @@ function modelsMapToDot(models, showEntityFields = false) {
     Object.keys(src).forEach(srcField => {
       src[srcField].forEach(relatedEntity => {
         const portPart = showEntityFields ? `:${srcField}` : '';
-        connections.push(`${displayName}${portPart} -> ${relatedEntity} [${props.join(',')}];`);
+        connections.push(`${displayName}${portPart} -> "${relatedEntity}" [${props.join(',')}];`);
       });
     });
   };


### PR DESCRIPTION
The app breaks if the display name of the component has special characters like:
```
[module] - Info Box
```
Those will be picked up by the `dot` as special attributes.