### PR TITLE
Fix #7 - Use contentful ID as node ID and escape special charaters for node labels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-    "extends": "airbnb-base"
+  extends: 'airbnb-base',
 };

--- a/import.js
+++ b/import.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 require('dotenv').config();
 
@@ -56,7 +57,7 @@ async function run() {
 
   const options = {
     hideEntityFields: argv.n || argv['no-fields'],
-    dev: argv.dev || argv.d
+    dev: argv.dev || argv.d,
   };
 
   const modelsMap = convertApi.contentTypesToModelMap(contentTypes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -716,6 +716,16 @@
         }
       }
     },
+    "eslint-plugin-mocha": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
+      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.1.0",
+        "ramda": "^0.27.1"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1626,6 +1636,12 @@
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "mocha",
-    "lint": "eslint src/**/*.js",
+    "lint": "eslint src/**/*.js test/**/*.js ./*.js",
     "start": "./import.js"
   },
   "contributors": [
@@ -40,6 +40,7 @@
     "eslint": "^7.14.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-mocha": "^8.0.0",
     "mocha": "^8.2.1"
   },
   "keywords": [

--- a/src/content-types-to-model-map.js
+++ b/src/content-types-to-model-map.js
@@ -12,7 +12,8 @@ function contentTypesToModelMap(types) {
   const modelsMap = {};
 
   types.items.forEach((type) => {
-    modelsMap[type.name] = {
+    modelsMap[type.sys.id] = {
+      name: type.name,
       fields: type.fields,
       relations: getRelations(type, types.items),
       sys: type.sys,

--- a/src/get-relations.js
+++ b/src/get-relations.js
@@ -1,4 +1,3 @@
-
 const hasValues = require('./has-values');
 const {
   TYPE_LINK, TYPE_RICH_TEXT, LINK_TYPE_ASSET, LINK_TYPE_ENTRY, RICH_TEXT_ENTRY_LINK_TYPES,
@@ -11,11 +10,11 @@ function getRelations(contentType, allTypes) {
     many: {},
   };
 
-  const allTypesSysId = allTypes ? allTypes.map(typeObj => typeObj.sys.id) : [];
+  const allTypesSysId = allTypes ? allTypes.map((typeObj) => typeObj.sys.id) : [];
 
-  const getTypeName = (searchType) => {
-    const model = allTypes.filter(type => type.sys.id === searchType).pop();
-    return model ? model.name : `[ Unknown type: ${searchType} ]`;
+  const getTypeId = (searchType) => {
+    const model = allTypes.filter((type) => type.sys.id === searchType).pop();
+    return model ? model.sys.id : `[ Unknown type: ${searchType} ]`;
   };
 
   const addRelation = (relType, fieldId, linkType, validations) => {
@@ -30,7 +29,7 @@ function getRelations(contentType, allTypes) {
       relations[relType][fieldId] = relations[relType][fieldId].concat(
         validations.reduce((arr, validation) => {
           if (hasValues(validation.linkContentType)) {
-            return arr.concat(validation.linkContentType.map(getTypeName));
+            return arr.concat(validation.linkContentType.map(getTypeId));
           } if (typeof validation.linkContentType === 'string') {
             return [validation.linkContentType];
           }
@@ -40,8 +39,8 @@ function getRelations(contentType, allTypes) {
     }
   };
   const checkRichTextValidationAndAddRelations = (fieldId, richTextValidations) => {
-    const nodeTypesEditorConfig = richTextValidations.filter(validationObj => typeof validationObj.enabledNodeTypes !== 'undefined')[0];
-    const nodesRestrictionConfig = richTextValidations.filter(validationObj => typeof validationObj.nodes !== 'undefined')[0];
+    const nodeTypesEditorConfig = richTextValidations.filter((validationObj) => typeof validationObj.enabledNodeTypes !== 'undefined')[0];
+    const nodesRestrictionConfig = richTextValidations.filter((validationObj) => typeof validationObj.nodes !== 'undefined')[0];
     /**
      *
      * @param {string} entryLinkType
@@ -52,7 +51,7 @@ function getRelations(contentType, allTypes) {
       if (typeof entryLinkTypeRestrictionsArray === 'undefined') {
         return undefined;
       }
-      const restrictionConfig = entryLinkTypeRestrictionsArray.filter(obj => Object.keys(obj).includes('linkContentType'))[0];
+      const restrictionConfig = entryLinkTypeRestrictionsArray.filter((obj) => Object.keys(obj).includes('linkContentType'))[0];
       if (typeof restrictionConfig !== 'undefined') {
         return restrictionConfig.linkContentType;
       }
@@ -66,10 +65,9 @@ function getRelations(contentType, allTypes) {
       return;
     }
     const doesEditorConfigRestrictAnyField = typeof nodeTypesEditorConfig !== 'undefined' && hasValues(nodeTypesEditorConfig.enabledNodeTypes);
-    const assetLinkAllowed = !doesEditorConfigRestrictAnyField || nodeTypesEditorConfig.enabledNodeTypes.filter(it => it.includes('asset')).length > 0;
-    const entryLinkAllowed = !doesEditorConfigRestrictAnyField || nodeTypesEditorConfig.enabledNodeTypes.filter(it => it.includes('entry')).length > 0;
-    const entryLinkTypes = doesEditorConfigRestrictAnyField ? nodeTypesEditorConfig.enabledNodeTypes.filter(it => it.includes('entry')) : RICH_TEXT_ENTRY_LINK_TYPES;
-
+    const assetLinkAllowed = !doesEditorConfigRestrictAnyField || nodeTypesEditorConfig.enabledNodeTypes.filter((it) => it.includes('asset')).length > 0;
+    const entryLinkAllowed = !doesEditorConfigRestrictAnyField || nodeTypesEditorConfig.enabledNodeTypes.filter((it) => it.includes('entry')).length > 0;
+    const entryLinkTypes = doesEditorConfigRestrictAnyField ? nodeTypesEditorConfig.enabledNodeTypes.filter((it) => it.includes('entry')) : RICH_TEXT_ENTRY_LINK_TYPES;
 
     if (assetLinkAllowed) {
       addRelation('many', fieldId, LINK_TYPE_ASSET, []);
@@ -85,10 +83,10 @@ function getRelations(contentType, allTypes) {
           return getContentRestrictionList;
         },
       ).reduce((prev, current) => {
-        current.forEach(nodeRevKey => prev.add(nodeRevKey));
+        current.forEach((nodeRevKey) => prev.add(nodeRevKey));
         return prev;
       }, new Set())
-        .forEach(linkedEntry => linkedEntriesAsArray.push(linkedEntry));
+        .forEach((linkedEntry) => linkedEntriesAsArray.push(linkedEntry));
       addRelation('many', fieldId, LINK_TYPE_ENTRY, [{ linkContentType: linkedEntriesAsArray }]);
     }
   };

--- a/src/has-values.js
+++ b/src/has-values.js
@@ -1,3 +1,3 @@
-const hasValues = val => Array.isArray(val) && val.length > 0;
+const hasValues = (val) => Array.isArray(val) && val.length > 0;
 
 module.exports = hasValues;

--- a/src/models-map-to-dot.js
+++ b/src/models-map-to-dot.js
@@ -29,18 +29,19 @@ function modelsMapToDot(models, { hideEntityFields, dev } = {}) {
     });
   };
 
-  const fieldMap = field => `<${field.id}> ${field.name}`;
-  const fieldMapDev = field => `<${field.id}> [${field.id}] ${field.id}`;
+  const fieldMap = (field) => `<${field.id}> ${field.name}`;
+  const fieldMapDev = (field) => `<${field.id}> [${field.id}] ${field.name}`;
 
-  Object.keys(models).forEach((modelName) => {
-    const model = models[modelName];
+  Object.keys(models).forEach((modelsSysId) => {
+    const model = models[modelsSysId];
+    const modelName = model.name;
 
     const fields = model.fields.map(dev ? fieldMapDev : fieldMap);
 
     if (hideEntityFields) {
-      objects[modelName] = `"${modelName}";`;
+      objects[modelsSysId] = `"${modelsSysId}";`;
     } else {
-      objects[modelName] = `"${modelName}" [label="{${
+      objects[modelsSysId] = `"${modelsSysId}" [label="{${
         dev ? `[${model.sys.id}] ${modelName}` : modelName
       } |          | ${fields.join('|').replace(/"/g, "'")}}" shape=Mrecord];`;
     }
@@ -51,8 +52,8 @@ function modelsMapToDot(models, { hideEntityFields, dev } = {}) {
       objects[LINK_TYPE_ASSET] = `"${LINK_TYPE_ASSET}";`;
     }
 
-    mapRelations(modelName, rels.one, ['dir=forward']);
-    mapRelations(modelName, rels.many, ['dir=forward', 'label="0..*"']);
+    mapRelations(modelsSysId, rels.one, ['dir=forward']);
+    mapRelations(modelsSysId, rels.many, ['dir=forward', 'label="0..*"']);
   });
 
   const dot = `

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     mocha: true,
+    node: true,
   },
   rules: {
 

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  env: {
+    mocha: true,
+  },
+  rules: {
+
+  },
+};

--- a/test/content-types-to-model-map.js
+++ b/test/content-types-to-model-map.js
@@ -1,13 +1,11 @@
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 
 const convertApi = require('../src/index');
 
-describe('typesToModelMap', function () {
-  it('should build empty relations', function () {
+describe('typesToModelMap', () => {
+  it('should build empty relations', () => {
     const emptyTypes = {
-      items: []
+      items: [],
     };
 
     assert.deepEqual(convertApi.contentTypesToModelMap(emptyTypes), {}, 'Model not empty');

--- a/test/fixtures/models-contentful-example-app.dot
+++ b/test/fixtures/models-contentful-example-app.dot
@@ -1,0 +1,33 @@
+
+digraph obj {
+  node[shape=record];
+
+  "course" [label="{Course |          | <title> Title|<slug> Slug|<image> Image|<shortDescription> Short Description|<description> Description|<duration> Duration|<skillLevel> Skill Level|<lessons> Lessons|<categories> Categories}" shape=Mrecord];
+  "layoutCopy" [label="{Layout \> Copy |          | <title> Title|<headline> Headline|<copy> Copy|<ctaTitle> CTA Title|<ctaLink> CTA Link|<visualStyle> Visual Style}" shape=Mrecord];
+  "layoutHeroImage" [label="{Layout \> Hero Image |          | <title> Title|<headline> Headline|<backgroundImage> Background Image}" shape=Mrecord];
+  "lesson" [label="{Lesson |          | <title> Title|<slug> Slug|<modules> Modules}" shape=Mrecord];
+  "category" [label="{Category |          | <title> Title|<slug> Slug}" shape=Mrecord];
+  "lessonCodeSnippets" [label="{Lesson \> Code Snippets |          | <title> Title|<curl> cURL|<dotNet> DotNet|<javascript> Javascript|<java> Java|<javaAndroid> Java-android|<php> Php|<python> Python|<ruby> Ruby|<swift> Swift}" shape=Mrecord];
+  "layoutHighlightedCourse" [label="{Layout \> Highlighted Course |          | <title> Title|<course> Course}" shape=Mrecord];
+  "lessonCopy" [label="{Lesson \> Copy |          | <title> Title|<copy> Copy}" shape=Mrecord];
+  "layout" [label="{Layout |          | <title> Title|<slug> Slug|<contentModules> Content Modules}" shape=Mrecord];
+  "lessonImage" [label="{Lesson \> Image |          | <title> Title|<image> Image|<caption> Caption}" shape=Mrecord];
+  "multiTestCharacters" [label="{Multi \<\> Test \\ \| Character |          | <title> Title|<image> Image|<caption> Caption \>\\\|\< chars}" shape=Mrecord];
+
+  edge [color="#e6194B"];
+  "course":"lessons" -> "lesson" [dir=forward,label="0..*"];
+  edge [color="#3cb44b"];
+  "course":"categories" -> "category" [dir=forward,label="0..*"];
+  edge [color="#e6194B"];
+  "lesson":"modules" -> "lessonCodeSnippets" [dir=forward,label="0..*"];
+  edge [color="#e6194B"];
+  "lesson":"modules" -> "lessonCopy" [dir=forward,label="0..*"];
+  edge [color="#e6194B"];
+  "lesson":"modules" -> "lessonImage" [dir=forward,label="0..*"];
+  edge [color="#e6194B"];
+  "layout":"contentModules" -> "layoutCopy" [dir=forward,label="0..*"];
+  edge [color="#e6194B"];
+  "layout":"contentModules" -> "layoutHeroImage" [dir=forward,label="0..*"];
+  edge [color="#e6194B"];
+  "layout":"contentModules" -> "layoutHighlightedCourse" [dir=forward,label="0..*"];
+}

--- a/test/fixtures/models-contentful-example-app.json
+++ b/test/fixtures/models-contentful-example-app.json
@@ -1,0 +1,785 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 10,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "course",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:18.939Z",
+        "updatedAt": "2017-12-14T17:29:17.052Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 3
+      },
+      "displayField": "title",
+      "name": "Course",
+      "description": "A series of lessons designed to teach sets of concepts that enable students to master Contentful.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "shortDescription",
+          "name": "Short Description",
+          "type": "Symbol",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "description",
+          "name": "Description",
+          "type": "Text",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "duration",
+          "name": "Duration",
+          "type": "Integer",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "skillLevel",
+          "name": "Skill Level",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "lessons",
+          "name": "Lessons",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "lesson"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        },
+        {
+          "id": "categories",
+          "name": "Categories",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "category"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "layoutCopy",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:17.774Z",
+        "updatedAt": "2017-12-14T17:27:24.185Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 3
+      },
+      "displayField": "title",
+      "name": "Layout > Copy",
+      "description": "A block of text with a headline and a call to action to be shown on the landing page.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "headline",
+          "name": "Headline",
+          "type": "Symbol",
+          "localized": true,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "copy",
+          "name": "Copy",
+          "type": "Text",
+          "localized": true,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "ctaTitle",
+          "name": "CTA Title",
+          "type": "Symbol",
+          "localized": true,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "ctaLink",
+          "name": "CTA Link",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "visualStyle",
+          "name": "Visual Style",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "layoutHeroImage",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:21.302Z",
+        "updatedAt": "2017-12-12T14:26:36.597Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 3
+      },
+      "displayField": "title",
+      "name": "Layout > Hero Image",
+      "description": "A hero image and header text.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "headline",
+          "name": "Headline",
+          "type": "Symbol",
+          "localized": true,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "backgroundImage",
+          "name": "Background Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "lesson",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:27.042Z",
+        "updatedAt": "2017-11-22T12:55:20.215Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 2
+      },
+      "displayField": "title",
+      "name": "Lesson",
+      "description": "A educational lesson, representing one section of a course.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "modules",
+          "name": "Modules",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "lessonCodeSnippets",
+                  "lessonCopy",
+                  "lessonImage"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "category",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:16.631Z",
+        "updatedAt": "2017-11-15T16:06:49.101Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 2
+      },
+      "displayField": "title",
+      "name": "Category",
+      "description": "Categories can be applied to Courses and Lessons. Assigning Multiple categories is also possible.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "lessonCodeSnippets",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:25.859Z",
+        "updatedAt": "2017-11-09T09:45:30.529Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 2
+      },
+      "displayField": "title",
+      "name": "Lesson > Code Snippets",
+      "description": "A code snippet module supporting all platforms to be used in a lesson.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "curl",
+          "name": "cURL",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "dotNet",
+          "name": "DotNet",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "javascript",
+          "name": "Javascript",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "java",
+          "name": "Java",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "javaAndroid",
+          "name": "Java-android",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "php",
+          "name": "Php",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "python",
+          "name": "Python",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "ruby",
+          "name": "Ruby",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "swift",
+          "name": "Swift",
+          "type": "Text",
+          "localized": false,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "layoutHighlightedCourse",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:20.057Z",
+        "updatedAt": "2017-11-09T09:45:19.450Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 2
+      },
+      "displayField": "title",
+      "name": "Layout > Highlighted Course",
+      "description": "A curated selection of highlighted courses.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "course",
+          "name": "Course",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "lessonCopy",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:23.545Z",
+        "updatedAt": "2017-11-09T09:44:58.462Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 2
+      },
+      "displayField": "title",
+      "name": "Lesson > Copy",
+      "description": "A markdown module to be used in a lesson.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "copy",
+          "name": "Copy",
+          "type": "Text",
+          "localized": true,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "layout",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:24.618Z",
+        "updatedAt": "2017-11-08T16:06:24.618Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1
+      },
+      "displayField": "title",
+      "name": "Layout",
+      "description": "A page consisting of freely configurable and rearrangeable content modules.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "contentModules",
+          "name": "Content Modules",
+          "type": "Array",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "layoutCopy",
+                  "layoutHeroImage",
+                  "layoutHighlightedCourse"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "lessonImage",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:22.406Z",
+        "updatedAt": "2017-11-08T16:06:22.406Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1
+      },
+      "displayField": "title",
+      "name": "Lesson > Image",
+      "description": "An image to be used as a module in a lesson.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "caption",
+          "name": "Caption",
+          "type": "Symbol",
+          "localized": true,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "qz0n5cdakyl9"
+          }
+        },
+        "id": "multiTestCharacters",
+        "type": "ContentType",
+        "createdAt": "2017-11-08T16:06:22.406Z",
+        "updatedAt": "2017-11-08T16:06:22.406Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1
+      },
+      "displayField": "title",
+      "name": "Multi <> Test \\ | Character",
+      "description": "An image to be used as a module in a lesson.",
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "caption",
+          "name": "Caption >\\|< chars",
+          "type": "Symbol",
+          "localized": true,
+          "required": false,
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/models-photo-gallery-dev.dot
+++ b/test/fixtures/models-photo-gallery-dev.dot
@@ -1,23 +1,23 @@
 digraph obj {
   node[shape=record];
 
-  "Photo Gallery" [label="{[7leLzv8hW06amGmke86y8G] Photo Gallery |          | <title> [title] title|<slug> [slug] slug|<author> [author] author|<coverImage> [coverImage] coverImage|<description> [description] description|<images> [images] images|<tags> [tags] tags|<date> [date] date|<location> [location] location}" shape=Mrecord];
+  "photoGallery" [label="{[photoGallery] Photo Gallery |          | <title> [title] Title|<slug> [slug] Slug|<author> [author] Author|<coverImage> [coverImage] Cover Image|<description> [description] Description|<images> [images] Images|<tags> [tags] Tags|<date> [date] Date|<location> [location] Location}" shape=Mrecord];
   "Asset";
-  "Image" [label="{[1xYw5JsIecuGE68mmGMg20] Image |          | <title> [title] title|<photo> [photo] photo|<imageCaption> [imageCaption] imageCaption|<imageCredits> [imageCredits] imageCredits|<categoryId> [categoryId] categoryId}" shape=Mrecord];
-  "Author" [label="{[38nK0gXXIccQ2IEosyAg6C] Author |          | <name> [name] name|<twitterHandle> [twitterHandle] twitterHandle|<profilePhoto> [profilePhoto] profilePhoto|<biography> [biography] biography|<createdEntries> [createdEntries] createdEntries}" shape=Mrecord];
-  "Category" [label="{[category] Category |          | <categoryId> [categoryId] categoryId|<categoryName> [categoryName] categoryName}" shape=Mrecord];
+  "image" [label="{[image] Image |          | <title> [title] Title|<photo> [photo] Photo|<imageCaption> [imageCaption] Image caption|<imageCredits> [imageCredits] Image credits|<categoryId> [categoryId] CategoryId}" shape=Mrecord];
+  "author" [label="{[author] Author |          | <name> [name] Name|<twitterHandle> [twitterHandle] Twitter handle|<profilePhoto> [profilePhoto] Profile photo|<biography> [biography] Biography|<createdEntries> [createdEntries] Created entries}" shape=Mrecord];
+  "category" [label="{[category] Category |          | <categoryId> [categoryId] Category Id|<categoryName> [categoryName] Category name}" shape=Mrecord];
   edge [color="#e6194B"];
-  "Photo Gallery":"author" -> "Author" [dir=forward];
+  "photoGallery":"author" -> "author" [dir=forward];
   edge [color="#3cb44b"];
-  "Photo Gallery":"coverImage" -> "Asset" [dir=forward];
+  "photoGallery":"coverImage" -> "Asset" [dir=forward];
   edge [color="#e6194B"];
-  "Photo Gallery":"images" -> "Image" [dir=forward,label="0..*"];
+  "photoGallery":"images" -> "image" [dir=forward,label="0..*"];
   edge [color="#e6194B"];
-  "Image":"photo" -> "Asset" [dir=forward];
+  "image":"photo" -> "Asset" [dir=forward];
   edge [color="#3cb44b"];
-  "Image":"categoryId" -> "Category" [dir=forward];
+  "image":"categoryId" -> "category" [dir=forward];
   edge [color="#e6194B"];
-  "Author":"profilePhoto" -> "Asset" [dir=forward];
+  "author":"profilePhoto" -> "Asset" [dir=forward];
   edge [color="#e6194B"];
-  "Author":"createdEntries" -> "Image" [dir=forward,label="0..*"];
+  "author":"createdEntries" -> "image" [dir=forward,label="0..*"];
 }

--- a/test/fixtures/models-photo-gallery-nofields.dot
+++ b/test/fixtures/models-photo-gallery-nofields.dot
@@ -1,23 +1,23 @@
 digraph obj {
   node[shape=record];
 
-  "Photo Gallery";
+  "photoGallery";
   "Asset";
-  "Image";
-  "Author";
-  "Category";
+  "image";
+  "author";
+  "category";
   edge [color="#e6194B"];
-  "Photo Gallery" -> "Author" [dir=forward];
+  "photoGallery" -> "author" [dir=forward];
   edge [color="#3cb44b"];
-  "Photo Gallery" -> "Asset" [dir=forward];
+  "photoGallery" -> "Asset" [dir=forward];
   edge [color="#e6194B"];
-  "Photo Gallery" -> "Image" [dir=forward,label="0..*"];
+  "photoGallery" -> "image" [dir=forward,label="0..*"];
   edge [color="#e6194B"];
-  "Image" -> "Asset" [dir=forward];
+  "image" -> "Asset" [dir=forward];
   edge [color="#3cb44b"];
-  "Image" -> "Category" [dir=forward];
+  "image" -> "category" [dir=forward];
   edge [color="#e6194B"];
-  "Author" -> "Asset" [dir=forward];
+  "author" -> "Asset" [dir=forward];
   edge [color="#e6194B"];
-  "Author" -> "Image" [dir=forward,label="0..*"];
+  "author" -> "image" [dir=forward,label="0..*"];
 }

--- a/test/fixtures/models-photo-gallery.dot
+++ b/test/fixtures/models-photo-gallery.dot
@@ -1,23 +1,23 @@
 digraph obj {
   node[shape=record];
 
-  "Photo Gallery" [label="{Photo Gallery |          | <title> Title|<slug> Slug|<author> Author|<coverImage> Cover Image|<description> Description|<images> Images|<tags> Tags|<date> Date|<location> Location}" shape=Mrecord];
+  "photoGallery" [label="{Photo Gallery |          | <title> Title|<slug> Slug|<author> Author|<coverImage> Cover Image|<description> Description|<images> Images|<tags> Tags|<date> Date|<location> Location}" shape=Mrecord];
   "Asset";
-  "Image" [label="{Image |          | <title> Title|<photo> Photo|<imageCaption> Image caption|<imageCredits> Image credits|<categoryId> CategoryId}" shape=Mrecord];
-  "Author" [label="{Author |          | <name> Name|<twitterHandle> Twitter handle|<profilePhoto> Profile photo|<biography> Biography|<createdEntries> Created entries}" shape=Mrecord];
-  "Category" [label="{Category |          | <categoryId> Category Id|<categoryName> Category name}" shape=Mrecord];
+  "image" [label="{Image |          | <title> Title|<photo> Photo|<imageCaption> Image caption|<imageCredits> Image credits|<categoryId> CategoryId}" shape=Mrecord];
+  "author" [label="{Author |          | <name> Name|<twitterHandle> Twitter handle|<profilePhoto> Profile photo|<biography> Biography|<createdEntries> Created entries}" shape=Mrecord];
+  "category" [label="{Category |          | <categoryId> Category Id|<categoryName> Category name}" shape=Mrecord];
   edge [color="#e6194B"];
-  "Photo Gallery":"author" -> "Author" [dir=forward];
+  "photoGallery":"author" -> "author" [dir=forward];
   edge [color="#3cb44b"];
-  "Photo Gallery":"coverImage" -> "Asset" [dir=forward];
+  "photoGallery":"coverImage" -> "Asset" [dir=forward];
   edge [color="#e6194B"];
-  "Photo Gallery":"images" -> "Image" [dir=forward,label="0..*"];
+  "photoGallery":"images" -> "image" [dir=forward,label="0..*"];
   edge [color="#e6194B"];
-  "Image":"photo" -> "Asset" [dir=forward];
+  "image":"photo" -> "Asset" [dir=forward];
   edge [color="#3cb44b"];
-  "Image":"categoryId" -> "Category" [dir=forward];
+  "image":"categoryId" -> "category" [dir=forward];
   edge [color="#e6194B"];
-  "Author":"profilePhoto" -> "Asset" [dir=forward];
+  "author":"profilePhoto" -> "Asset" [dir=forward];
   edge [color="#e6194B"];
-  "Author":"createdEntries" -> "Image" [dir=forward,label="0..*"];
+  "author":"createdEntries" -> "image" [dir=forward,label="0..*"];
 }

--- a/test/fixtures/models-photo-gallery.json
+++ b/test/fixtures/models-photo-gallery.json
@@ -15,7 +15,7 @@
             "id": "jxpgsakrn9ub"
           }
         },
-        "id": "7leLzv8hW06amGmke86y8G",
+        "id": "photoGallery",
         "type": "ContentType",
         "createdAt": "2017-06-03T22:57:33.113Z",
         "updatedAt": "2017-06-03T22:57:33.585Z",
@@ -79,7 +79,7 @@
           "validations": [
             {
               "linkContentType": [
-                "38nK0gXXIccQ2IEosyAg6C"
+                "author"
               ]
             }
           ],
@@ -126,7 +126,7 @@
             "validations": [
               {
                 "linkContentType": [
-                  "1xYw5JsIecuGE68mmGMg20"
+                  "image"
                 ]
               }
             ],
@@ -178,7 +178,7 @@
             "id": "jxpgsakrn9ub"
           }
         },
-        "id": "1xYw5JsIecuGE68mmGMg20",
+        "id": "image",
         "type": "ContentType",
         "createdAt": "2017-06-03T22:57:32.995Z",
         "updatedAt": "2017-06-06T18:43:03.770Z",
@@ -286,7 +286,7 @@
             "id": "jxpgsakrn9ub"
           }
         },
-        "id": "38nK0gXXIccQ2IEosyAg6C",
+        "id": "author",
         "type": "ContentType",
         "createdAt": "2017-06-03T22:57:33.094Z",
         "updatedAt": "2017-06-03T22:57:33.609Z",
@@ -380,7 +380,7 @@
             "validations": [
               {
                 "linkContentType": [
-                  "1xYw5JsIecuGE68mmGMg20"
+                  "image"
                 ]
               }
             ],

--- a/test/get-relations.js
+++ b/test/get-relations.js
@@ -1,4 +1,3 @@
-/* eslint-env node, mocha */
 const assert = require('assert');
 
 const getRelations = require('../src/get-relations');

--- a/test/get-relations.js
+++ b/test/get-relations.js
@@ -62,7 +62,7 @@ describe('getRelations', () => {
       _hasAssets: true,
       one: {},
       many: {
-        enableEverythingRichText: ['Asset', 'foreign Model', 'Model with wildcard richtext'],
+        enableEverythingRichText: ['Asset', 'foreignModel', 'modelWithWildcardRichText'],
       },
     };
     assert.deepStrictEqual(getRelations(contentType, allItems), expected, 'Does not link to all types');
@@ -227,7 +227,7 @@ describe('getRelations', () => {
       _hasAssets: false,
       one: {},
       many: {
-        richText: ['foreign Model', 'Model with richtext'],
+        richText: ['foreignModel', 'modelWithRichText'],
       },
     };
     assert.deepStrictEqual(getRelations(contentType, allItems), expected, 'Does not link to assets or link to entries');
@@ -289,7 +289,7 @@ describe('getRelations', () => {
       _hasAssets: false,
       one: {},
       many: {
-        richText: ['foreign Model'],
+        richText: ['foreignModel'],
       },
     };
     assert.deepStrictEqual(getRelations(contentType, allItems), expected, 'Does not only link to foreignModel');

--- a/test/has-values.js
+++ b/test/has-values.js
@@ -1,16 +1,16 @@
 const assert = require('assert');
 
-const hasValues = require('../src/has-values')
+const hasValues = require('../src/has-values');
 
-describe('hasValues', function () {
-  it('should return true when values are present', function() {
-    assert.ok(hasValues([1,2]), 'Should have values')
-    assert.ok(hasValues(["one"]), 'Should have values')
+describe('hasValues', () => {
+  it('should return true when values are present', () => {
+    assert.ok(hasValues([1, 2]), 'Should have values');
+    assert.ok(hasValues(['one']), 'Should have values');
   });
-  it('should return false when not array', function() {
-    assert.notEqual(hasValues([]), true, 'Should not have values')
-    assert.notEqual(hasValues({}), true, 'Should not have values')
-    assert.notEqual(hasValues(null), true, 'Should not have values')
-    assert.notEqual(hasValues(''), true, 'Should not have values')
+  it('should return false when not array', () => {
+    assert.notEqual(hasValues([]), true, 'Should not have values');
+    assert.notEqual(hasValues({}), true, 'Should not have values');
+    assert.notEqual(hasValues(null), true, 'Should not have values');
+    assert.notEqual(hasValues(''), true, 'Should not have values');
   });
 });

--- a/test/models-map-to-dot.js
+++ b/test/models-map-to-dot.js
@@ -1,13 +1,14 @@
+/* eslint-disable global-require */
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const convertApi = require('../src/index')
+const convertApi = require('../src/index');
 
-describe('modelsToDot', function () {
+describe('modelsToDot', () => {
   const unspace = (str) => str.replace(/^\s+/mg, '');
 
-  it('should build empty graph', function () {
+  it('should build empty graph', () => {
     const result = convertApi.modelsMapToDot({});
     const expected = `
 digraph obj {
@@ -20,41 +21,40 @@ digraph obj {
     assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 
-  it('should render sample graph with fields', function () {
+  it('should render sample graph with fields', () => {
     const sampleModel = require('./fixtures/models-photo-gallery.json');
     const expected = fs.readFileSync(path.join(__dirname, './fixtures/models-photo-gallery.dot'), 'utf-8');
 
     const modelMap = convertApi.contentTypesToModelMap(sampleModel);
     const result = convertApi.modelsMapToDot(modelMap, {
-      hideEntityFields: false
+      hideEntityFields: false,
     });
 
     assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 
-  it('should render sample graph with dev information', function () {
+  it('should render sample graph with dev information', () => {
     const sampleModel = require('./fixtures/models-photo-gallery.json');
     const expected = fs.readFileSync(path.join(__dirname, './fixtures/models-photo-gallery-dev.dot'), 'utf-8');
 
     const modelMap = convertApi.contentTypesToModelMap(sampleModel);
     const result = convertApi.modelsMapToDot(modelMap, {
       hideEntityFields: false,
-      dev: true
+      dev: true,
     });
 
     assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 
-  it('should render sample graph without fields', function () {
+  it('should render sample graph without fields', () => {
     const sampleModel = require('./fixtures/models-photo-gallery.json');
     const expected = fs.readFileSync(path.join(__dirname, './fixtures/models-photo-gallery-nofields.dot'), 'utf-8');
 
     const modelMap = convertApi.contentTypesToModelMap(sampleModel);
     const result = convertApi.modelsMapToDot(modelMap, {
-      hideEntityFields: true
+      hideEntityFields: true,
     });
 
     assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
   });
-
 });

--- a/test/models-map-to-dot.js
+++ b/test/models-map-to-dot.js
@@ -18,7 +18,7 @@ digraph obj {
 }
 `;
 
-    assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
+    assert.strictEqual(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 
   it('should render sample graph with fields', () => {
@@ -30,7 +30,7 @@ digraph obj {
       hideEntityFields: false,
     });
 
-    assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
+    assert.strictEqual(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 
   it('should render sample graph with dev information', () => {
@@ -43,7 +43,7 @@ digraph obj {
       dev: true,
     });
 
-    assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
+    assert.strictEqual(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 
   it('should render sample graph without fields', () => {
@@ -55,6 +55,19 @@ digraph obj {
       hideEntityFields: true,
     });
 
-    assert.equal(unspace(result), unspace(expected), 'Graph doesnt match');
+    assert.strictEqual(unspace(result), unspace(expected), 'Graph doesnt match');
+  });
+
+  it('should escape <>\\| in the labels', () => {
+    const sampleModel = require('./fixtures/models-contentful-example-app.json');
+    const expected = fs.readFileSync(path.join(__dirname, './fixtures/models-contentful-example-app.dot'), 'utf-8');
+
+    const modelMap = convertApi.contentTypesToModelMap(sampleModel);
+    const result = convertApi.modelsMapToDot(modelMap, {
+      hideEntityFields: false,
+      dev: false,
+    });
+
+    assert.strictEqual(unspace(result), unspace(expected), 'Graph doesnt match');
   });
 });


### PR DESCRIPTION
Fix #7 by implement update the way how a `dot` file is generated.
- Use the field `sys.id` for each content model as a node identifier.
- Escape the special characters `<>\|` in names for fields or the model

Additional:
- Ensure lint on tests and on `import.js`.
- Fix lint issues