### PR TITLE
Solves #52 - Content type naming is equal for all cases.

### DIFF
--- a/src/models-map-to-dot.js
+++ b/src/models-map-to-dot.js
@@ -36,7 +36,7 @@ function modelsMapToDot(models, { hideEntityFields, dev } = {}) {
   Object.keys(models).forEach((modelsSysId) => {
     const model = models[modelsSysId];
     const modelName = sanitizeNamesForLabelInDot(model.name);
-    const modelLabel = dev ? `[${model.sys.id}] ${modelName}` : modelName
+    const modelLabel = dev ? `[${model.sys.id}] ${modelName}` : modelName;
     const fields = model.fields.map(dev ? fieldMapDev : fieldMap);
 
     if (hideEntityFields) {

--- a/src/models-map-to-dot.js
+++ b/src/models-map-to-dot.js
@@ -36,15 +36,13 @@ function modelsMapToDot(models, { hideEntityFields, dev } = {}) {
   Object.keys(models).forEach((modelsSysId) => {
     const model = models[modelsSysId];
     const modelName = sanitizeNamesForLabelInDot(model.name);
-
+    const modelLabel = dev ? `[${model.sys.id}] ${modelName}` : modelName
     const fields = model.fields.map(dev ? fieldMapDev : fieldMap);
 
     if (hideEntityFields) {
-      objects[modelsSysId] = `"${modelsSysId}";`;
+      objects[modelsSysId] = `"${modelsSysId}" [label="${modelLabel}"];`;
     } else {
-      objects[modelsSysId] = `"${modelsSysId}" [label="{${
-        dev ? `[${model.sys.id}] ${modelName}` : modelName
-      } |          | ${fields.join('|').replace(/"/g, "'")}}" shape=Mrecord];`;
+      objects[modelsSysId] = `"${modelsSysId}" [label="{${modelLabel} |          | ${fields.join('|').replace(/"/g, "'")}}" shape=Mrecord];`;
     }
 
     const rels = model.relations;

--- a/test/fixtures/models-photo-gallery-nofields-dev.dot
+++ b/test/fixtures/models-photo-gallery-nofields-dev.dot
@@ -1,11 +1,11 @@
 digraph obj {
   node[shape=record];
 
-  "photoGallery" [label="Photo Gallery"];
+  "photoGallery" [label="[photoGallery] Photo Gallery"];
   "Asset";
-  "image" [label="Image"];
-  "author" [label="Author"];
-  "category" [label="Category"];
+  "image" [label="[image] Image"];
+  "author" [label="[author] Author"];
+  "category" [label="[category] Category"];
   edge [color="#e6194B"];
   "photoGallery" -> "author" [dir=forward];
   edge [color="#3cb44b"];

--- a/test/models-map-to-dot.js
+++ b/test/models-map-to-dot.js
@@ -51,6 +51,19 @@ digraph obj {
     assert.strictEqual(unspace(result), unspace(normalizeLineEndings(expected)), 'Graph doesnt match');
   });
 
+  it('should render sample graph with dev information and without fields', () => {
+    const sampleModel = require('./fixtures/models-photo-gallery.json');
+    const expected = fs.readFileSync(path.join(__dirname, './fixtures/models-photo-gallery-nofields-dev.dot'), 'utf-8');
+
+    const modelMap = convertApi.contentTypesToModelMap(sampleModel);
+    const result = convertApi.modelsMapToDot(modelMap, {
+      hideEntityFields: true,
+      dev: true,
+    });
+
+    assert.strictEqual(unspace(result), unspace(normalizeLineEndings(expected)), 'Graph doesnt match');
+  });
+
   it('should render sample graph without fields', () => {
     const sampleModel = require('./fixtures/models-photo-gallery.json');
     const expected = fs.readFileSync(path.join(__dirname, './fixtures/models-photo-gallery-nofields.dot'), 'utf-8');


### PR DESCRIPTION
Regardless of the flags: The content type name is always shown.

With `-d` or `--dev`: The content type ID is prefixed to the name